### PR TITLE
Stack operators

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,7 +98,7 @@ source8 = R"""
 {
   dup 2 <
     { }
-    { dup 1 - rot3 * swap n!-impl } parent-scope
+    { dup 1 - unrot * swap n!-impl } parent-scope
     if !
 } parent-scope :n!-impl jar
 
@@ -150,7 +150,7 @@ parent-scope :pjar jar
 { { } parent-scope close close }
 :--make-generator pjar
 
-{ rot3 swap --make-generator swap jar }
+{ rot --make-generator swap jar }
 :generator pjar
 
 { iterate forever }
@@ -162,7 +162,7 @@ parent-scope :pjar jar
   swap dup
   println
   (1 100) sleep
-  swap dup rot3 +
+  swap dup rot +
 }
 parent-scope
 (1 (1 ()))
@@ -173,14 +173,14 @@ fib forever
 
 source12 = R"""
 :math (* -) import
-{ { (. .) { dup 1 - rot3 * swap n! }
+{ { (. .) { dup 1 - rot * swap n! }
     (1) {}
   } case
 } :n! jar
 1 10 n!
 """
 
-stack, scope = vm.run(parse(source12))
+stack, scope = vm.run(parse(source10))
 
 print("\n----------------")
 print("Resulting stack:")

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -1,20 +1,6 @@
 from pytest import raises
 
-import gurklang.vm as vm
-from gurklang.parser import parse
-from gurklang.types import Int
-
-
-def run(code):
-    stack, _ = vm.run(parse(code))
-    return stack
-
-
-def number_stack(*args):
-    stack = None
-    for arg in args:
-        stack = Int(arg), stack
-    return stack
+from .test_examples import run, number_stack
 
 
 def test_case_value_match():

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,57 @@
+import gurklang.vm as vm
+from gurklang.parser import parse
+from gurklang.types import Int
+
+
+def run(code):
+    stack, _ = vm.run(parse(code))
+    return stack
+
+
+def number_stack(*args):
+    stack = None
+    for arg in args:
+        stack = Int(arg), stack
+    return stack
+
+
+def test_factorial():
+    assert run(R"""
+    :math (* -) import
+    { { (. .) { dup 1 - rot * swap n! }
+        (1) {}
+      } case
+    } :n! jar
+    1 10 n!
+    """) == number_stack(3628800)
+
+
+def test_generators(capsys):
+    run(R"""
+    :math ( +       ) import
+    :coro ( iterate ) import
+
+    { dup println 1 + } (1 ())
+    iterate
+    iterate
+    iterate
+    iterate
+    """)
+    assert capsys.readouterr().out == '1\n2\n3\n4\n'
+
+
+def test_higher_order_functions(capsys):
+    run(R"""
+    :math ( + ) import
+    :inspect ( code-dump ) import
+
+    { :f var :x var { x f ! } } :my-close jar
+
+    { { + } my-close } :make-adder jar
+
+    5 make-adder :add5 jar
+
+    37 add5 println  #=> 42
+    40 add5 println  #=> 45
+    """)
+    assert capsys.readouterr().out == '42\n45\n'

--- a/tests/test_prelude.py
+++ b/tests/test_prelude.py
@@ -1,18 +1,4 @@
-import gurklang.vm as vm
-from gurklang.parser import parse
-from gurklang.types import Int
-
-
-def run(code):
-    stack, _ = vm.run(parse(code))
-    return stack
-
-
-def nums(*args):
-    stack = None
-    for arg in args:
-        stack = Int(arg), stack
-    return stack
+from .test_examples import run, number_stack as nums
 
 
 def test_dup():

--- a/tests/test_prelude.py
+++ b/tests/test_prelude.py
@@ -1,0 +1,51 @@
+import gurklang.vm as vm
+from gurklang.parser import parse
+from gurklang.types import Int
+
+
+def run(code):
+    stack, _ = vm.run(parse(code))
+    return stack
+
+
+def nums(*args):
+    stack = None
+    for arg in args:
+        stack = Int(arg), stack
+    return stack
+
+
+def test_dup():
+    assert run('3 dup') == nums(3, 3)
+    assert run('3 4 2dup') == nums(3, 4, 3, 4)
+
+
+def test_drop():
+    assert run('3 4 drop') == nums(3)
+    assert run('3 4 2drop') == nums()
+
+
+def test_swap():
+    assert run('3 4 swap') == nums(4, 3)
+    assert run('3 4 5 6 2swap') == nums(5, 6, 3, 4)
+
+
+def test_over():
+    assert run('3 4 over') == nums(3, 4, 3)
+    assert run('3 4 5 6 2over') == nums(3, 4, 5, 6, 3, 4)
+
+
+def test_rot():
+    assert run('3 4 5 rot') == nums(5, 3, 4)
+    assert run('3 4 5 6 7 8 2rot') == nums(7, 8, 3, 4, 5, 6)
+
+
+def test_unrot():
+    assert run('3 4 5 unrot') == nums(4, 5, 3)
+    assert run('3 4 5 6 7 8 2unrot') == nums(5, 6, 7, 8, 3, 4)
+
+
+def test_rot_identities():
+    assert run('3 4 5 rot rot') == run('3 4 5 unrot')
+    assert run('3 4 5 rot rot rot') == run('3 4 5 unrot unrot unrot') == nums(3, 4, 5)
+    assert run('3 4 5 rot unrot rot unrot') == nums(3, 4, 5)


### PR DESCRIPTION
implements the following stack operators
```elixir
dup   ( a - a a )
drop  ( a - )
swap  ( a b - b a )
over  ( a b - a b a )
rot   ( a b c - b c a )
unrot  ( a b c - c a b )
nip   ( a b - b )
tuck  ( a b - b a b )
``` as well as their variants that operate on pair rather than single stack values, prefixed by 2.
also adds tests for them, as well as edits examples to work correctly, and adds several of the examples to tests.