### PR TITLE
Make string manipulation easier using streams

### DIFF
--- a/gurklang/stdlib_modules/__init__.py
+++ b/gurklang/stdlib_modules/__init__.py
@@ -4,7 +4,7 @@ Standard library modules that aren't built-ins
 from typing import List, TYPE_CHECKING
 if TYPE_CHECKING:
     from gurklang.builtin_utils import Module
-from . import math, inspect, coro, repl_utils, boxes, threading_, strings, recursion, ds_pure, ds
+from . import math, inspect, coro, repl_utils, boxes, threading_, strings, recursion, ds_pure, ds, streams
 
 
 modules: "List[Module]" = [
@@ -15,6 +15,7 @@ modules: "List[Module]" = [
     boxes.module,
     threading_.module,
     strings.module,
+    streams.module,
 
     recursion.module,
     ds_pure.module,

--- a/gurklang/stdlib_modules/streams.py
+++ b/gurklang/stdlib_modules/streams.py
@@ -13,7 +13,7 @@ def make_stream(s: str, i: int = 0):
         if i < len(s):
             return Str(s[i]), (make_stream(s, i + 1), stack)
         else:
-            return Atom.make('stream-end'), (make_stream(s, i), stack)
+            return Atom('stream-end'), (__str_stream, stack)
 
     return __str_stream
 
@@ -21,6 +21,6 @@ def make_stream(s: str, i: int = 0):
 @module.register_simple('str->stream')
 def str_to_stream(stack: T[V, S], fail: Fail):
     s, r = stack
-    if s.tag == 'str':
-        return make_stream(s.value), r
-    fail(f'{s} is not a string')
+    if s.tag != 'str':
+        fail(f'{s} is not a string')
+    return make_stream(s.value), r

--- a/gurklang/stdlib_modules/streams.py
+++ b/gurklang/stdlib_modules/streams.py
@@ -1,0 +1,26 @@
+from typing import Tuple
+
+from ..builtin_utils import BuiltinModule, Fail, make_simple
+from ..types import Value, Stack, Str, Atom
+
+module = BuiltinModule("streams")
+T, V, S = Tuple, Value, Stack
+
+
+def make_stream(s: str, i: int = 0):
+    @make_simple()
+    def __str_stream(stack: S, fail: Fail):
+        if i < len(s):
+            return Str(s[i]), (make_stream(s, i + 1), stack)
+        else:
+            return Atom.make('stream-end'), (make_stream(s, i), stack)
+
+    return __str_stream
+
+
+@module.register_simple('str->stream')
+def str_to_stream(stack: T[V, S], fail: Fail):
+    s, r = stack
+    if s.tag == 'str':
+        return make_stream(s.value), r
+    fail(f'{s} is not a string')

--- a/tests/stdlib/test_streams.py
+++ b/tests/stdlib/test_streams.py
@@ -1,0 +1,12 @@
+from ..test_examples import run
+
+
+def test_string_stream():
+    assert run("""
+    :streams (str->stream) import
+    '123' str->stream 
+    ! swap
+    ! swap
+    ! swap
+    ! nip
+    """) == run("'1' '2' '3' :stream-end")


### PR DESCRIPTION
Allows efficient recursive traversal of strings, doesn't require non utf8 encoding like indexed access would. Once join or some other string constructor is implemented, this would allow a very simple gurklang parser in gurklang.