### PR TITLE
Add more string functions

### DIFF
--- a/gurklang/stdlib_modules/strings.py
+++ b/gurklang/stdlib_modules/strings.py
@@ -1,12 +1,73 @@
-from typing import Callable, TypeVar, Tuple
-from ..vm_utils import render_value_as_source
+from typing import TypeVar, Tuple
+
 from ..builtin_utils import BuiltinModule, Fail, make_function, raw_function, make_simple
-from ..types import CallByName, CallByValue, NativeFunction, Put, State, Str, Value, Stack, Scope, Int
-import random
+from ..types import CallByValue, Put, State, Str, Value, Stack, Int, Atom
+from ..vm_utils import render_value_as_source
 
 module = BuiltinModule("strings")
 T, V, S = Tuple, Value, Stack
 Z = TypeVar("Z", bound=Stack)
+
+_UNARY_STRING_TO_STRING = [
+    ('casefold', 'fold-case'),
+    ('lower', '->lower'),
+    ('upper', '->upper'),
+    ('swapcase', 'swap-case'),
+    ('title', '->title'),
+]
+_UNARY_STRING_TO_BOOL = [
+    ('is' + w, w + '?')
+    for w in 'alnum alpha ascii decimal digit identifier lower numeric printable space title upper'.split()
+]
+
+
+def _register_delegated_methods():
+    for function, name in _UNARY_STRING_TO_STRING:
+        method = getattr(str, function)
+
+        def fun(stack: T[V, S], fail: Fail, method=method):
+            arg, rest = stack
+            if arg.tag != 'str':
+                fail('argument is not a string')
+            return Str(method(arg.value)), rest
+
+        module.register_simple(name)(fun)
+
+    for function, name in _UNARY_STRING_TO_BOOL:
+        method = getattr(str, function)
+
+        def fun(stack: T[V, S], fail: Fail, method=method):
+            arg, rest = stack
+            if arg.tag != 'str':
+                fail('argument is not a string')
+            return Atom('true') if method(arg.value) else Atom('false'), rest
+
+        module.register_simple(name)(fun)
+
+
+_register_delegated_methods()
+
+
+@module.register_simple()
+def join_list(stack: T[V, T[V, S]], fail: Fail):
+    sep, (strs, rest) = stack
+    if sep.tag != 'str':
+        fail('join requires a string as a separator')
+    if strs.tag != 'vec':
+        fail('join requires a list of strings as its argument')
+    el = strs.values
+    strings = []
+    while len(el) != 0:
+        if len(el) != 2:
+            fail('a list must be composed of 2 long tuples')
+        car, cdr = el
+        if cdr.tag != 'vec':
+            fail('a list must only contain tuples as the second element')
+        if car.tag != 'str':
+            fail('all elements of the list passed to join must be strings')
+        strings.append(car.value)
+        el = cdr.values
+    return Str(sep.value.join(strings)), rest
 
 
 @make_simple()
@@ -19,6 +80,7 @@ def __foreach_str_init(stack: T[V, T[V, S]], fail: Fail):
         fail(f"{render_value_as_source(fn)} is not a function")
 
     return (__foreach_str_step, (Int(0), (fn, (s, rest))))
+
 
 @make_function()
 def __foreach_str_step(state: State, fail: Fail) -> State:
@@ -42,6 +104,7 @@ def __foreach_str_step(state: State, fail: Fail) -> State:
             .push(__bootstrap_foreach_step)
             .push(Str(s.value[index.value]))
             .push(fn))
+
 
 __bootstrap_foreach_step = raw_function(
     Put(__foreach_str_step),

--- a/gurklang/stdlib_modules/strings.py
+++ b/gurklang/stdlib_modules/strings.py
@@ -25,22 +25,24 @@ def _register_delegated_methods():
     for function, name in _UNARY_STRING_TO_STRING:
         method = getattr(str, function)
 
+        #  closures capture by name, so not passing method as a default argument would only use the last method
+        @module.register_simple(name)
         def fun(stack: T[V, S], fail: Fail, method=method):
             arg, rest = stack
             if arg.tag != 'str':
                 fail('argument is not a string')
             return Str(method(arg.value)), rest
 
-        module.register_simple(name)(fun)
-
     for function, name in _UNARY_STRING_TO_BOOL:
         method = getattr(str, function)
 
+        #  closures capture by name, so not passing method as a default argument would only use the last method
+        @module.register_simple(name)
         def fun(stack: T[V, S], fail: Fail, method=method):
             arg, rest = stack
             if arg.tag != 'str':
                 fail('argument is not a string')
-            return Atom('true') if method(arg.value) else Atom('false'), rest
+            return Atom.bool(method(arg.value)), rest
 
         module.register_simple(name)(fun)
 

--- a/tests/stdlib/test_strings.py
+++ b/tests/stdlib/test_strings.py
@@ -1,5 +1,6 @@
 from ..test_examples import run
 
+
 def test_foreach_str():
     actual = run("""
     :math ( + ) import
@@ -20,3 +21,20 @@ def test_foreach_str():
     expected = run("7")
 
     assert expected == actual
+
+
+# it may be worth making a hypothesis test here, but IDK how to go about that
+def test_delegated_methods():
+    assert run("""
+        :strings ( ->lower ->upper numeric? ) import
+        "Hello WoRlD" ->lower
+        "Hello WoRlD" ->upper
+        "Hello WoRlD" numeric?
+    """) == run("""'hello world' 'HELLO WORLD' :false""")
+
+
+def test_join_list():
+    assert run("""
+        :strings (join-list) import
+        ("A" ("B" ("CDEF" ()))) "," join-list
+    """) == run("'A,B,CDEF'")


### PR DESCRIPTION
join would allow a reasonable gurklang parser in gurklang. We may want `join-stream` in the future, but due to the complexity of traversing streams from python I will leave this to a future PR.

if you find the autogenerated string functions bad, I will just write it out, but this is slightly less repetetive.