### PR TITLE
Implement basic IO functions, should be helpful if we actually want to do AOC in this

### DIFF
--- a/gurklang/stdlib_modules/__init__.py
+++ b/gurklang/stdlib_modules/__init__.py
@@ -4,7 +4,7 @@ Standard library modules that aren't built-ins
 from typing import List, TYPE_CHECKING
 if TYPE_CHECKING:
     from gurklang.builtin_utils import Module
-from . import math, inspect, coro, repl_utils, boxes, threading_, strings, recursion, ds_pure, ds, streams
+from . import math, inspect, coro, repl_utils, boxes, threading_, strings, recursion, ds_pure, ds, streams, io
 
 
 modules: "List[Module]" = [
@@ -16,7 +16,7 @@ modules: "List[Module]" = [
     threading_.module,
     strings.module,
     streams.module,
-
+    io.module,
     recursion.module,
     ds_pure.module,
     ds.module,

--- a/gurklang/stdlib_modules/io.py
+++ b/gurklang/stdlib_modules/io.py
@@ -1,0 +1,17 @@
+from ..builtin_utils import BuiltinModule, Fail
+from ..types import Str, Value, Stack, Tuple
+from pathlib import Path
+import sys
+
+module = BuiltinModule('io')
+
+T, V, S = Tuple, Value, Stack
+
+@module.register_simple()
+def read(stack: T[V, S], fail: Fail):
+    path, rest = stack
+    if path.tag == "str":
+        return Str(Path(path.value).read_text()), rest
+    if path.tag == "atom" and path.value == "in":
+        return sys.stdin.read(), rest
+    fail("read works on the :in atom and a filepath string")

--- a/gurklang/stdlib_modules/io.py
+++ b/gurklang/stdlib_modules/io.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import Iterable, TextIO
 from ..builtin_utils import BuiltinModule, Fail, make_simple
 from ..types import Atom, Str, Value, Stack, Tuple
 from pathlib import Path
@@ -18,10 +18,14 @@ def read(stack: T[V, S], fail: Fail):
     fail("read works on the :in atom and a filepath string")
 
     
-def lines_as_stream(file: Iterable[str]):
+def lines_as_stream(file: TextIO):
     @make_simple()
     def __file_stream(stack: S, fail: Fail):
-        return next(map(Str, file), Atom("stream-end")), (__file_stream, stack)
+        try:
+            return Str(next(file)), (__file_stream, stack)
+        except (StopIteration, ValueError):
+            file.close()
+            return Atom("stream-end"), (__file_stream , stack)
 
     return __file_stream
 


### PR DESCRIPTION
`read` reads the whole file as a single string

`lines` reads the file as a stream of lines

both can take :in to mean stdin (possibly extend this to files in arguments like in raku, ruby, fileinput from python)