### PR TITLE
Add a list to stream function

### DIFF
--- a/gurklang/stdlib_modules/streams.py
+++ b/gurklang/stdlib_modules/streams.py
@@ -1,21 +1,32 @@
 from typing import Tuple
 
 from ..builtin_utils import BuiltinModule, Fail, make_simple
-from ..types import Value, Stack, Str, Atom
+from ..types import Value, Stack, Str, Atom, Vec
 
 module = BuiltinModule("streams")
 T, V, S = Tuple, Value, Stack
 
 
-def make_stream(s: str, i: int = 0):
+def make_str_stream(s: str, i: int = 0):
     @make_simple()
     def __str_stream(stack: S, fail: Fail):
         if i < len(s):
-            return Str(s[i]), (make_stream(s, i + 1), stack)
+            return Str(s[i]), (make_str_stream(s, i + 1), stack)
         else:
             return Atom('stream-end'), (__str_stream, stack)
 
     return __str_stream
+
+
+def make_tuple_stream(s: Vec, i: int = 0):
+    @make_simple()
+    def __tuple_stream(stack: S, fail: Fail):
+        if i < len(s):
+            return s[i], (make_tuple_stream(s, i + 1), stack)
+        else:
+            return Atom('stream-end'), (__tuple_stream, stack)
+
+    return __tuple_stream
 
 
 @module.register_simple('str->stream')
@@ -23,4 +34,12 @@ def str_to_stream(stack: T[V, S], fail: Fail):
     s, r = stack
     if s.tag != 'str':
         fail(f'{s} is not a string')
-    return make_stream(s.value), r
+    return make_str_stream(s.value), r
+
+
+@module.register_simple('tuple->stream')
+def tuple_to_stream(stack: T[V, S], fail: Fail):
+    s, r = stack
+    if s.tag != 'vec':
+        fail(f'{s} is not a tuple')
+    return make_tuple_stream(s.values), r 

--- a/gurklang/stdlib_modules/streams.py
+++ b/gurklang/stdlib_modules/streams.py
@@ -18,19 +18,19 @@ def make_str_stream(s: str, i: int = 0):
     return __str_stream
 
 
-def make_tuple_stream(s: List[Vec]):
+def make_list_stream(s: List[Vec]):
     @make_simple()
-    def __tuple_stream(stack: S, fail: Fail):
+    def __list_stream(stack: S, fail: Fail):
         if s == []:
-            return Atom('stream-end'), (__tuple_stream, stack)
+            return Atom('stream-end'), (__list_stream, stack)
         if len(s) != 2:
-            fail('a list must be composed of 2 long tuples')
+            fail('a list must be composed of 2 long lists')
         head, tail = s
         if tail.tag != 'vec':
-            fail('a list must only contain tuples as the second element')
-        return head, (make_tuple_stream(tail.values), stack)
+            fail('a list must only contain lists as the second element')
+        return head, (make_list_stream(tail.values), stack)
 
-    return __tuple_stream
+    return __list_stream
 
 
 @module.register_simple('str->stream')
@@ -41,9 +41,9 @@ def str_to_stream(stack: T[V, S], fail: Fail):
     return make_str_stream(s.value), r
 
 
-@module.register_simple('tuple->stream')
-def tuple_to_stream(stack: T[V, S], fail: Fail):
+@module.register_simple('list->stream')
+def list_to_stream(stack: T[V, S], fail: Fail):
     s, r = stack
     if s.tag != 'vec':
-        fail(f'{s} is not a tuple')
-    return make_tuple_stream(s.values), r
+        fail(f'{s} is not a list')
+    return make_list_stream(s.values), r

--- a/gurklang/stdlib_modules/streams.py
+++ b/gurklang/stdlib_modules/streams.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import List, Tuple
 
 from ..builtin_utils import BuiltinModule, Fail, make_simple
 from ..types import Value, Stack, Str, Atom, Vec
@@ -18,13 +18,17 @@ def make_str_stream(s: str, i: int = 0):
     return __str_stream
 
 
-def make_tuple_stream(s: Vec, i: int = 0):
+def make_tuple_stream(s: List[Vec]):
     @make_simple()
     def __tuple_stream(stack: S, fail: Fail):
-        if i < len(s):
-            return s[i], (make_tuple_stream(s, i + 1), stack)
-        else:
+        if s == []:
             return Atom('stream-end'), (__tuple_stream, stack)
+        if len(s) != 2:
+            fail('a list must be composed of 2 long tuples')
+        head, tail = s
+        if tail.tag != 'vec':
+            fail('a list must only contain tuples as the second element')
+        return head, (make_tuple_stream(tail.values), stack)
 
     return __tuple_stream
 
@@ -42,4 +46,4 @@ def tuple_to_stream(stack: T[V, S], fail: Fail):
     s, r = stack
     if s.tag != 'vec':
         fail(f'{s} is not a tuple')
-    return make_tuple_stream(s.values), r 
+    return make_tuple_stream(s.values), r


### PR DESCRIPTION
Does the name seem right to you, or should we call it something like `vec->stream`?

Sample usage:
```elixir
>>> :streams ( tuple->stream ) import
>>> ("Hi" ("there" ("human" ()))) tuple->stream
>>> ! println
"Hi"
>>> ! println
"there"
>>> ! println
"human"
>>> ! println
:stream-end
```