### PR TITLE
Conversions stdlib module with conversions between tuple and list

### DIFF
--- a/gurklang/stdlib_modules/__init__.py
+++ b/gurklang/stdlib_modules/__init__.py
@@ -4,7 +4,7 @@ Standard library modules that aren't built-ins
 from typing import List, TYPE_CHECKING
 if TYPE_CHECKING:
     from gurklang.builtin_utils import Module
-from . import math, inspect, coro, repl_utils, boxes, threading_, strings, recursion, ds_pure, ds, streams, io
+from . import math, inspect, coro, repl_utils, boxes, threading_, strings, recursion, ds_pure, ds, streams, io, conversions
 
 
 modules: "List[Module]" = [
@@ -20,4 +20,5 @@ modules: "List[Module]" = [
     recursion.module,
     ds_pure.module,
     ds.module,
+    conversions.module,
 ]

--- a/gurklang/stdlib_modules/conversions.py
+++ b/gurklang/stdlib_modules/conversions.py
@@ -14,3 +14,22 @@ def tuple_to_list(stack: T[V, S], fail: Fail):
         fail(f"{head} must be a tuple")
     nested = reduce(lambda a, b: Vec([b, a]), reversed(head.values), Vec([]))
     return nested, rest
+
+
+@module.register_simple("list->tuple")
+def list_to_tuple(stack: T[V, S], fail: Fail):
+    head, rest = stack
+    if head.tag != "vec":
+        fail(f"{head} must be a list")
+    el = head.values
+    values = []
+    while len(el) != 0:
+        if len(el) != 2:
+            fail('a list must be composed of 2 long tuples')
+        car, cdr = el
+        if cdr.tag != 'vec':
+            fail('a list must only contain tuples as the second element')
+        values.append(car)
+        el = cdr.values
+
+    return Vec(values), rest

--- a/gurklang/stdlib_modules/conversions.py
+++ b/gurklang/stdlib_modules/conversions.py
@@ -1,0 +1,16 @@
+from functools import reduce
+from ..builtin_utils import BuiltinModule, Fail
+from ..types import Tuple, Value, Stack, Vec
+
+
+module = BuiltinModule("conversions")
+T, V, S = Tuple, Value, Stack
+
+
+@module.register_simple("tuple->list")
+def tuple_to_list(stack: T[V, S], fail: Fail):
+    head, rest = stack
+    if head.tag != "vec":
+        fail(f"{head} must be a tuple")
+    nested = reduce(lambda a, b: Vec([b, a]), reversed(head.values), Vec([]))
+    return nested, rest


### PR DESCRIPTION
`list` refers to a linked list, while `tuple` refers to a "flat" tuple. Conversions between the two types is now supported:
```elixir
>>> :conversions ( tuple->list list->tuple ) import
>>> (1 2 3 4 5) tuple->list dup println
(1 (2 (3 (4 (5 ())))))
>>> list->tuple println
(1 2 3 4 5)
```
The idea is that we'll add virtually all conversion functions to the conversions module, so we don't need to figure out in which module the conversion function exists, every time we need to convert between values.

Let's get this merged before migrating everything though.