### PR TITLE
Add a basic setup.py

### DIFF
--- a/gurklang/__main__.py
+++ b/gurklang/__main__.py
@@ -1,33 +1,3 @@
-import sys
-from . import repl, vm, parser
-
-args = sys.argv[1:]
-
-if args == []:
-    repl.repl()
-elif args == ["-i"]:
-    source = sys.stdin.read()
-    parsed = parser.parse(source)
-    vm.run(parsed)
-elif args[0] == "-r":
-    filename = args[1]
-    with open(filename) as source_file:
-        source = source_file.read()
-    repl.run_and_open_repl(source)
-elif len(args) == 1:
-    filename = args[0]
-    with open(filename) as source_file:
-        source = source_file.read()
-    parsed = parser.parse(source)
-    vm.run(parsed)
-elif args[0] == "-c":
-    source = " ".join(args[1:])
-    parsed = parser.parse(source)
-    vm.run(parsed)
-else:
-    print("Invalid arguments. Valid execution modes:")
-    print("gurklang : open the REPL")
-    print("gurklang path/to/file : run a program from file")
-    print("gurklang -r path/to/file : run a program from file and open the REPL")
-    print("gurklang -c 'program' : run a program specified in the arguments after `-c`")
-    print("gurklang -i : run a program read from the standard input")
+from . import entrypoint
+if __name__ == '__main__':
+    entrypoint.entrypoint()

--- a/gurklang/entrypoint.py
+++ b/gurklang/entrypoint.py
@@ -1,0 +1,34 @@
+import sys
+from . import repl, vm, parser
+
+def entrypoint():
+    args = sys.argv[1:]
+
+    if args == []:
+        repl.repl()
+    elif args == ["-i"]:
+        source = sys.stdin.read()
+        parsed = parser.parse(source)
+        vm.run(parsed)
+    elif args[0] == "-r":
+        filename = args[1]
+        with open(filename) as source_file:
+            source = source_file.read()
+        repl.run_and_open_repl(source)
+    elif len(args) == 1:
+        filename = args[0]
+        with open(filename) as source_file:
+            source = source_file.read()
+        parsed = parser.parse(source)
+        vm.run(parsed)
+    elif args[0] == "-c":
+        source = " ".join(args[1:])
+        parsed = parser.parse(source)
+        vm.run(parsed)
+    else:
+        print("Invalid arguments. Valid execution modes:")
+        print("gurklang : open the REPL")
+        print("gurklang path/to/file : run a program from file")
+        print("gurklang -r path/to/file : run a program from file and open the REPL")
+        print("gurklang -c 'program' : run a program specified in the arguments after `-c`")
+        print("gurklang -i : run a program read from the standard input")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[options]
+install_requires = 
+    immutables
+    click
+    colorama
+[options.entry_points]
+console_scripts =
+    gurklang = gurklang.entrypoint:entrypoint

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ here = Path(__file__).parent.resolve()
 long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
-    name='py-gurklang',
+    name='gurklang',
     version='0.0.1',
     description='a python runtime for gurklang',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from  setuptools import setup, find_packages
+from pathlib import Path
+here = Path(__file__).parent.resolve()
+
+long_description = (here / 'README.md').read_text(encoding='utf-8')
+
+setup(
+    name='py-gurklang',
+    version='0.0.1',
+    description='a python runtime for gurklang',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    url='https://github.com/gurkult/py-gurklang',
+    python_requires='>=3.8, <4',
+    packages=['gurklang', 'gurklang.stdlib_modules', 'gurklang.plugins']
+)


### PR DESCRIPTION
This allows using pip to install gurklang, whereas now we have to clone to repo etc. (well, we are using this branch to install, but just keeping it up to date forever seems unwise).